### PR TITLE
api key is created when user is created

### DIFF
--- a/src/actions/user-actions.js
+++ b/src/actions/user-actions.js
@@ -1,5 +1,6 @@
 import makeUser from "../entities/user.js";
 import hashPassword from "../helpers/hash-password.js";
+import generateToken from "../helpers/generate-token.js";
 import comparePassword from "../helpers/compare-password.js";
 
 export default function makeUserActions({ database } = {}) {
@@ -18,12 +19,7 @@ export default function makeUserActions({ database } = {}) {
             const db = await database;
             user._id = db.makeId();
             user.userPassword = hashPassword(user.userPassword);
-            //we want to create an api key that can be used by the application when a user logs in.
-            // user.apiKey = 
-            
-            
-            // crypto.randomUUID();
-
+            user.apiKey = generateToken(user._id);
             const processedUser = documentToUser(user);
 
             const emailCheck = await findUserByEmail(processedUser.userEmail);
@@ -70,7 +66,7 @@ export default function makeUserActions({ database } = {}) {
             }
 
             return (
-                {authenticatedUser: true}
+                {authenticatedUser: true, token: loginResult.userAPIKey}
             );
 
             

--- a/src/entities/user.js
+++ b/src/entities/user.js
@@ -20,6 +20,7 @@ export default function makeUser(userInfo) {
         userContactNumber,
         userAdmin,
         userPaymentDetails,
+        userAPIKey,
         ...otherInfo} = {}) 
     {
         validateEmail(userEmail);
@@ -32,6 +33,7 @@ export default function makeUser(userInfo) {
         validateContactNumber(userContactNumber);
         validateAdmin(userAdmin);
         validatePaymentDetails(userPaymentDetails);
+        validateAPIKey(userAPIKey);
         return {
             userEmail,
             userPassword,
@@ -43,6 +45,7 @@ export default function makeUser(userInfo) {
             userContactNumber,
             userAdmin,
             userPaymentDetails,
+            userAPIKey,
             ...otherInfo
         }
     }
@@ -116,8 +119,14 @@ export default function makeUser(userInfo) {
         }
     }
 
+    function validateAPIKey(key) {
+        if (typeCheck(key) != 'string') {
+            throw new Error('API Key is not a string')
+        }
+    }
 
-    function normalize({userEmail, userPassword, userFirstName, userLastName, userAddressLine1, userAddressLine2, userPostcode, userContactNumber, userAdmin, userPaymentDetails, ...otherInfo}) {
+
+    function normalize({userEmail, userPassword, userFirstName, userLastName, userAddressLine1, userAddressLine2, userPostcode, userContactNumber, userAdmin, userPaymentDetails, userAPIKey, ...otherInfo}) {
         return {
             userEmail: userEmail.toLowerCase(),
             userPassword: userPassword,
@@ -129,6 +138,7 @@ export default function makeUser(userInfo) {
             userContactNumber: userContactNumber,
             userAdmin: userAdmin,
             userPaymentDetails: userPaymentDetails,
+            userAPIKey: userAPIKey,
             ...otherInfo
         }
     }

--- a/src/helpers/generate-token.js
+++ b/src/helpers/generate-token.js
@@ -1,0 +1,10 @@
+import bcryptjs from "bcryptjs";
+import crypto from 'crypto';
+
+export default function generateToken(string) {
+    const saltRounds = 12;
+    let salt = bcryptjs.genSaltSync(saltRounds);
+    let saltedHash = bcryptjs.hashSync(string, salt);
+    const token = crypto.createHash('md5').update(saltedHash).digest('hex');
+    return token;
+}


### PR DESCRIPTION
This pull request introduces functionality to generate a hashed and encrypted API token when a user is added to the database. Moreover, it also introduces functionality that produces the token for consumption by the client upon successful login.

My next thought would be to rehash the token and save it to the database on logout.